### PR TITLE
a workaround for contextInfo data arriving nil in called selector

### DIFF
--- a/Settings/MFSettingsController.h
+++ b/Settings/MFSettingsController.h
@@ -31,6 +31,8 @@ MFLogViewerController, MGActionButton;
 	MFClient* client;
 	MFPreferencesController* preferencesController;
 	MFLogViewerController* logViewerController;
+    
+    NSMutableArray *newFilesystemsToDelete;
 }
 
 - (IBAction)newFSPopupClicked:(id)sender;
@@ -50,4 +52,5 @@ MFLogViewerController, MGActionButton;
 - (IBAction)openSupportSite:(id)sender;
 
 @property(readonly) MFClient* client;
+@property(readwrite, assign) NSMutableArray *newFilesystemsToDelete;
 @end

--- a/Settings/MFSettingsController.m
+++ b/Settings/MFSettingsController.m
@@ -30,6 +30,8 @@
 #import "MFPreferences.h"
 #import "MFLogging.h"
 
+
+
 @interface MFSettingsController(PrivateAPI)
 - (void)editFilesystem:(MFClientFS*)fs;
 - (void)toggleFilesystem:(MFClientFS*)fs;
@@ -305,10 +307,11 @@
 		NSButton *cancelButton = [deleteConfirmation addButtonWithTitle:@"Cancel"];
 		[cancelButton setKeyEquivalent:@"\e"];
 		[deleteConfirmation setAlertStyle: NSCriticalAlertStyle];
+        [self setNewFilesystemsToDelete:filesystemsToDelete];
 		[deleteConfirmation beginSheetModalForWindow: [filesystemTableView window]
 									   modalDelegate:self
 									  didEndSelector:@selector(deleteConfirmationAlertDidEnd:returnCode:contextInfo:)
-										 contextInfo:filesystemsToDelete];
+										 contextInfo:nil];
 	}
 }
 
@@ -366,13 +369,14 @@
 
 
 - (void)deleteConfirmationAlertDidEnd:(NSAlert*)alert returnCode:(NSInteger)code contextInfo:(void *)context {
-	NSArray *filesystemsToDelete = (NSArray *)context;
+    
 	if (code == NSAlertSecondButtonReturn) {
 		
 	} else if (code == NSAlertFirstButtonReturn) {
-		for(MFClientFS *fs in filesystemsToDelete) {
+		for(MFClientFS *fs in [self newFilesystemsToDelete]) {
 			[client deleteFilesystem: fs];	
 		}
+        [self setNewFilesystemsToDelete:[NSMutableArray alloc]];
 	}
 }
 
@@ -584,4 +588,5 @@
 }
 
 @synthesize client;
+@synthesize newFilesystemsToDelete;
 @end


### PR DESCRIPTION
This commit introduces a simple workaround to fix deleting of configured items.  The crash occurs because contextInfo is arriving nil in deleteConfirmationAlertDidEnd
