### PR TITLE
remove insecure ssh options

### DIFF
--- a/SSHFS/SSHFSDelegate.m
+++ b/SSHFS/SSHFSDelegate.m
@@ -58,8 +58,6 @@ static NSString *advancedViewControllerKey = @"sshfsAdvancedView";
 	[arguments addObject:[parameters objectForKey:kMFFSMountPathParameter]];
 	[arguments addObject:[NSString stringWithFormat:@"-p%@", [parameters objectForKey:kNetFSPortParameter]]];
 	
-	[arguments addObject:@"-oCheckHostIP=no"];
-	[arguments addObject:@"-oStrictHostKeyChecking=no"];
 	[arguments addObject:@"-oNumberOfPasswordPrompts=1"];
 	if ([[parameters objectForKey:kSSHFSFollowSymlinksParameter] boolValue] == YES) {
 		[arguments addObject:@"-ofollow_symlinks"];	


### PR DESCRIPTION
Hello,

First: Macfusion is a neat and useful tool; thanks for writing it.

The current code runs ssh with CheckHostIP=no and StrictHostKeyChecking=no on the command line. These are security-sensitive options which an application should not change without the user's knowledge. Setting hostkey checking this way is particularly bad, since in this mode Macfusion will silently connect to a spoofed server a user has specifically verified in the past (ssh issues a warning, but Macfusion ignores it and does not present it to the user).

I have removed the options; a user can add them in ~/.ssh/config or in the Macfusion "SSH Advanced" tab if he actually wants them.

– Richard Silverman
